### PR TITLE
Fix import path

### DIFF
--- a/helpers/firefoxPaths.js
+++ b/helpers/firefoxPaths.js
@@ -1,5 +1,6 @@
 import { platform, homedir } from "os";
-import { join, resolve, existsSync } from "path";
+import { join, resolve } from "path";
+import { existsSync } from "fs";
 
 export default function getFirefoxPaths() {
   const os = platform();


### PR DESCRIPTION
Related to https://github.com/Explosion-Scratch/firebuilder/issues/4

With https://github.com/Explosion-Scratch/firebuilder/commit/f1b93f1c83bf958767ec9de3e4a236fad816d46f, I still see a

> ./firebuilder-linux-x64
1 | (function (entry, fetcher)
    ^
SyntaxError: Export named 'existsSync' not found in module 'path'.

This fixes that.